### PR TITLE
Minor fixes to sponsorship pages

### DIFF
--- a/sponsor-packages.html
+++ b/sponsor-packages.html
@@ -142,7 +142,7 @@ bodytags: with-hero
       </tr>
 
       <tr>
-        <td colspan="2">A tweet before before the event</td>
+        <td colspan="2">A tweet before the event</td>
         <td>✔</td>
         <td>✔</td>
         <td>✔</td>
@@ -273,14 +273,14 @@ bodytags: with-hero
         <p>Help us keep RustFest's attendees well-caffeinated and alert at all times!</p>
         <p>For a conference that happens over a weekend, it's always important to make sure the attendees are up for whatever we can throw at them - even after a demanding week at work. This sponsorship allows us to provide them with coffee and tea throughout the whole weekend.</p>
         <p>The sponsorship allows the sponsor to provide one roll-up banner that will be presented next to the served coffee. The sponsor can provide a logo or graphics of their choice that will be printed on paper cups available at these stations.</p>
-        <p>RustFest reserves the right to refusing to include graphics on the coffee cups that go against the RustFest Code of Conduct, the values of the conference or the Rust community. In case a suitable graphics cannot be agreed upon, RustFest refunds the sponsorship amount and the sponsorship agreement is deemed canceled.</p>
+        <p class="smallprint">RustFest reserves the right to refusing to include graphics on the coffee cups that go against the RustFest Code of Conduct, the values of the conference or the Rust community. In case a suitable graphics cannot be agreed upon, RustFest refunds the sponsorship amount and the sponsorship agreement is deemed canceled.</p>
       </li>
 
       <li>
         <h3>Afterparty (a.k.a. Karaoke) Sponsor — 2&nbsp;000€</h3>
         <p>Support the closing social event after the conference's talk day!</p>
         <p>This sponsorship level includes a mention in the schedule and the day-closing remarks for the Afterparty sponsor.</p>
-        <p>Please note: the afterparty sponsorship does not give the sponsor any rights for prescribing the way the sponsorship is spent, choice in venue or included food and drinks. RustFest is strictly against serving free alcohol at RustFest events, and the sponsorship will not be used for such, either, but depending on the selected venue, alcoholic drinks might be available for purchase for the attendees of the event.</p>
+        <p class="smallprint">Please note: the afterparty sponsorship does not give the sponsor any rights for prescribing the way the sponsorship is spent, choice in venue or included food and drinks. RustFest is strictly against serving free alcohol at RustFest events, and the sponsorship will not be used for such, either, but depending on the selected venue, alcoholic drinks might be available for purchase for the attendees of the event.</p>
       </li>
 
     <blockquote id="note-1">Note: all additional sponsorship options can be selected individually, or as add-ons to any of the sponsorship tiers, <strong>with the exception</strong> of the Afterparty Sponsor option which can only be selected as an add-on to any (Bronze...Platinum) sponsorship package.</blockquote>


### PR DESCRIPTION
make smallprints small, remove doubled "before"