### PR TITLE
Add LAS as a post-event conference

### DIFF
--- a/pre-post-conf-events.md
+++ b/pre-post-conf-events.md
@@ -22,6 +22,7 @@ If you would like to submit your own event, please edit [this file](https://gith
 
 | Location |           When            |               What                |
 | -------- | ------------------------- | --------------------------------- |
+| Barcelona, Spain | 2019-11-12 to 2019-11-15 | [Linux App Summit](https://linuxappsummit.org/) Three day conference around Linux desktop applications ecosystem |
 | City, CC | 2019-09-XX, 18:00 - 21:00 | An example meeting [with link](#) |
 
 # The Map


### PR DESCRIPTION
It's not really Rust related (even though we're planning to have a Rust workshop) but some people may be interested given it's exactly after the rustfest